### PR TITLE
Metadata workshop

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ DH-Projekte, Bibliotheken, Archive und Forschende, die mit Zeitungs- und Zeitsch
 Von der Bilddigitalisierung über Text-, Bild- und Layouterkennung und Metadatenmodelle bis zu konkreten geisteswissenschaftlichen Forschungsfragen stellt die wissenschaftliche Beschäftigung mit Zeitungen und Zeitschriften im Bereich der DH Herausforderungen, die gemeinsam betrachtet werden sollten. Auf diese Weise werden Insellösungen, die eine Nachnutzung der Digitalisate, Metadaten und Forschungsresultate erschweren, vermieden und Kooperationen vereinfacht.
 
 ### Aktuelles   
-* 03.-04. September 2020 - [Metadaten Workshop der AG](https://dhd-blog.org/?p=14076)
+* 03.-04. September 2020 - [Metadaten Workshop der AG](https://dhd-ag-zz.github.io/workshops/2020-09_metadata_analysis)
 * [DHd2020 Paderborn](https://dhd2020.de/programm/) (02.-06. März 2020): Die AG lädt zu zwei Treffen ein:  
 1. Dienstag, 03. März, 12:00 - 13:30 (Q 5 245): Das Treffen dient der Nachbereitung des AG Workshops zum Thema ["OCR Herausforderungen und Lösungen für Zeitungen & Zeitschriften"](https://dhd-ag-zz.github.io/workshops/ocr_2019-11-11) - (Ansprechpartner: Dario Kampkaspar)  
 2. Mittwoch, 04. März, 12:30 - 14:00 (H5): Das Treffen ist für die Planung weiterer AG Aktivitäten gedacht und konkret für die Konzeption einer Workshopreihe mit dem Arbeitstitel "Transformation, Annotation, Interpretation" (Ansprechpartner: Nanette Rißler-Pipka, Torsten Roeder, Estelle Bunout, Matthias Arnold)

--- a/workshops/2020-09_metadata_analysis.md
+++ b/workshops/2020-09_metadata_analysis.md
@@ -7,4 +7,5 @@ In drei Schritten nähern wir uns dabei der Analyse der Metadaten und damit auch
 * Wie bearbeite ich die erhaltenen Metdaten weiter? Datenauswahl und -konvertierung
 * Wie analysiere und visualisiere ich die Metadaten gemäß meiner Forschungsfrage? Datenanalyse
 
-Alle Aufgaben werden in Python gelöst. Daher ist eine entsprechende technische Ausstattung Voraussetzung (Laptop mit Python vorinstalliert –  eine Anleitung wird bereit gestellt). Bereits vorhandene eigene Programmierkenntnisse sind nicht erforderlich, aber das entsprechende Interesse daran.
+Alle Aufgaben werden in Python gelöst. Daher ist eine entsprechende technische Ausstattung Voraussetzung (Laptop mit Python vorinstalliert –  eine Anleitung wird bereit gestellt). Bereits vorhandene eigene Programmierkenntnisse sind nicht erforderlich, aber das entsprechende Interesse daran. **Die Teilnehmerzahl ist auf 20 limitiert**. Bei der Anmeldung ist eine eigene Forschungsfrage anzugeben. Für die verbleibenden Plätze gilt das first-come-first-serve-Prinzip.
+

--- a/workshops/2020-09_metadata_analysis.md
+++ b/workshops/2020-09_metadata_analysis.md
@@ -1,0 +1,2 @@
+### Virtueller Workshop der DHd-AG Zeitungen & Zeitschriften zur Metadaten-Analyse
+

--- a/workshops/2020-09_metadata_analysis.md
+++ b/workshops/2020-09_metadata_analysis.md
@@ -1,2 +1,10 @@
 ### Virtueller Workshop der DHd-AG Zeitungen & Zeitschriften zur Metadaten-Analyse
 
+Die DHd-AG Zeitungen & Zeitschriften bietet am **3. und 4. September 2020 jeweils von 9-16 Uhr** einen virtuellen Workshop an, um anhand komplexer Beispiele der Medien Zeitungen und Zeitschriften zu zeigen, wie man an die Metadaten heran kommt, wie man sie danach weiter vorbereitet, um dann spezifische Forschungsfragen damit zu beantworten. Das Angebot digitaler Ressourcen zu Zeitungen und Zeitschriften beginnt beim Eintrag der bibliografischen Metadaten in Kataloge und Verzeichnisse und führt über die Metadaten aus dem Digitalisierungsprozess (Bild-Digitalisierung) bis hin zu den Metadaten des Volltexts (sollte dieser vorhanden sein). Teilnehmerinnen und Teilnehmer werden daher eingeladen, eine konkrete Forschungsfrage mitzubringen. Beispieldatensätze (aus Europeana Newspaper oder anderen Portalen wie der Deutschen Digitalen Bibliothek) werden bereit gestellt.
+
+In drei Schritten nähern wir uns dabei der Analyse der Metadaten und damit auch der Beantwortung individueller Forschungsfragen:
+* Wie komme ich an die Metadaten? Schnittstellen und Metadaten-Standards, Grundlagen und Praxis
+* Wie bearbeite ich die erhaltenen Metdaten weiter? Datenauswahl und -konvertierung
+* Wie analysiere und visualisiere ich die Metadaten gemäß meiner Forschungsfrage? Datenanalyse
+
+Alle Aufgaben werden in Python gelöst. Daher ist eine entsprechende technische Ausstattung Voraussetzung (Laptop mit Python vorinstalliert –  eine Anleitung wird bereit gestellt). Bereits vorhandene eigene Programmierkenntnisse sind nicht erforderlich, aber das entsprechende Interesse daran.


### PR DESCRIPTION
Unterseite zum Metadaten-Workshop samt Verlinkung auf der Startseite (index.md) unter "Aktuelles". Der Link zur Ankündigung auf dem Dhd-Blog wurde dadurch ersetzt.